### PR TITLE
Update release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ MANIFEST
 pyodeint/_odeint_numpy.pyx
 __conda_version__.txt
 **/.ipynb_checkpoints/
+**.egg-info

--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,10 @@ The classic van der Pol oscillator (see `examples/van_der_pol.py <examples/van_d
 For more examples see `examples/ <https://github.com/bjodah/pyodeint/tree/master/examples>`_, and rendered jupyter notebooks here:
 `<http://hera.physchem.kth.se/~pyodeint/branches/master/examples>`_
 
+See also
+--------
+`pyodesys <https://github.com/bjodah/pyodesys>`_ for how to automatically
+generate the jacobian callback function (and easily swtich to other solvers).
 
 License
 -------

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,28 +1,28 @@
 package:
-    name: pyodeint
-    version: 0.7.0.git
+  name: pyodeint
+  version: 0.7.0.git
 
 source:
-    path: ../
+  path: ../
 
 build:
-    number: 0
+  number: 0
 
 requirements:
-    build:
-        - python
-        - numpy
-        - boost
-        - cython
-    run:
-        - numpy
-        - python
+  build:
+    - python
+    - numpy
+    - boost
+    - cython
+  run:
+    - numpy
+    - python
 
 test:
-    imports:
-        - pyodeint
-    requires:
-        - pytest
+  imports:
+    - pyodeint
+  requires:
+    - pytest
 
 about:
     home: https://github.com/bjodah/pyodeint

--- a/scripts/build_conda_recipe.sh
+++ b/scripts/build_conda_recipe.sh
@@ -10,6 +10,4 @@ fi
 ./scripts/check_clean_repo_on_master.sh
 echo ${1#v}>__conda_version__.txt
 trap "rm __conda_version__.txt" EXIT SIGINT SIGTERM
-for CPY in {27,34}; do
-    PYTHONNOUSERSITE=1 CONDA_PY=$CPY conda build conda-recipe
-done
+PYTHONNOUSERSITE=1 conda build conda-recipe

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 # Usage:
 #
-#    $ ./scripts/release.sh v1.2.3
+#    $ ./scripts/release.sh v1.2.3 ~/anaconda2/bin
 #
 
 if [[ $1 != v* ]]; then
@@ -15,11 +15,27 @@ PKG=$(find . -maxdepth 2 -name __init__.py -print0 | xargs -0 -n1 dirname | xarg
 PKG_UPPER=$(echo $PKG | tr '[:lower:]' '[:upper:]')
 ./scripts/run_tests.sh
 env ${PKG_UPPER}_RELEASE_VERSION=$1 python setup.py sdist
-./scripts/build_conda_recipe.sh $1
+for CONDA_PY in 27 34 35; do
+    PATH=$2:$PATH CONDA_NPY=110 ./scripts/build_conda_recipe.sh $1
+done
 
 # All went well
 git tag -a $1 -m $1
 git push
 git push --tags
 twine upload dist/${PKG}-${1#v}.tar.gz
-echo "Remember to bump version (and commit and push)!"
+MD5=$(md5sum dist/${PKG}-$VERSION.tar.gz | cut -f1 -d' ')
+
+if [[ -d dist/conda-recipe-${1#v} ]]; then
+    rm -r dist/conda-recipe-${1#v}
+fi
+cp -r conda-recipe/ dist/conda-recipe-${1#v}
+sed -i -E -e "s/version:(.+)/version: $VERSION/" -e "s/path:(.+)/fn: $PKG-$VERSION.tar.gz\n    url: https:\/\/pypi.python.org\/packages\/source\/${PKG:0:1}\/$PKG\/$PKG-$VERSION.tar.gz#md5=$MD5\n    md5: $MD5/" -e '/cython/d' dist/conda-recipe-${1#v}/meta.yaml
+
+# Specific for this project:
+SERVER=hera
+scp -r dist/conda-recipe-${1#v}/ $PKG@$SERVER:~/public_html/conda-recipes/
+scp dist/${PKG}-$VERSION.tar.gz $PKG@$SERVER:~/public_html/releases/
+for CONDA_PY in 27 34 35; do
+    ssh $PKG@$SERVER "source /etc/profile; CONDA_PY=$CONDA_PY CONDA_NPY=110 conda-build ~/public_html/conda-recipes/conda-recipe-${1#v}/"
+done

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,10 +5,15 @@
 #
 
 if [[ $1 != v* ]]; then
-    echo "Argument does not start with 'v'"
+    >&2 echo "Argument does not start with 'v'"
+    exit 1
+fi
+if [[ $# -ne 2 ]]; then
+    >&2 echo "Need 2 arguments: vX.Y.Z ~/miniconda/bin"
     exit 1
 fi
 ./scripts/check_clean_repo_on_master.sh
+VERSION=${1#v}
 cd $(dirname $0)/..
 # PKG will be name of the directory one level up containing "__init__.py" 
 PKG=$(find . -maxdepth 2 -name __init__.py -print0 | xargs -0 -n1 dirname | xargs basename)
@@ -23,19 +28,19 @@ done
 git tag -a $1 -m $1
 git push
 git push --tags
-twine upload dist/${PKG}-${1#v}.tar.gz
+twine upload dist/${PKG}-$VERSION.tar.gz
 MD5=$(md5sum dist/${PKG}-$VERSION.tar.gz | cut -f1 -d' ')
 
-if [[ -d dist/conda-recipe-${1#v} ]]; then
-    rm -r dist/conda-recipe-${1#v}
+if [[ -d dist/conda-recipe-$VERSION ]]; then
+    rm -r dist/conda-recipe-$VERSION
 fi
-cp -r conda-recipe/ dist/conda-recipe-${1#v}
-sed -i -E -e "s/version:(.+)/version: $VERSION/" -e "s/path:(.+)/fn: $PKG-$VERSION.tar.gz\n    url: https:\/\/pypi.python.org\/packages\/source\/${PKG:0:1}\/$PKG\/$PKG-$VERSION.tar.gz#md5=$MD5\n    md5: $MD5/" -e '/cython/d' dist/conda-recipe-${1#v}/meta.yaml
+cp -r conda-recipe/ dist/conda-recipe-$VERSION
+sed -i -E -e "s/version:(.+)/version: $VERSION/" -e "s/path:(.+)/fn: $PKG-$VERSION.tar.gz\n  url: https:\/\/pypi.python.org\/packages\/source\/${PKG:0:1}\/$PKG\/$PKG-$VERSION.tar.gz#md5=$MD5\n  md5: $MD5/" -e '/cython/d' dist/conda-recipe-$VERSION/meta.yaml
 
 # Specific for this project:
 SERVER=hera
-scp -r dist/conda-recipe-${1#v}/ $PKG@$SERVER:~/public_html/conda-recipes/
+scp -r dist/conda-recipe-$VERSION/ $PKG@$SERVER:~/public_html/conda-recipes/
 scp dist/${PKG}-$VERSION.tar.gz $PKG@$SERVER:~/public_html/releases/
 for CONDA_PY in 27 34 35; do
-    ssh $PKG@$SERVER "source /etc/profile; CONDA_PY=$CONDA_PY CONDA_NPY=110 conda-build ~/public_html/conda-recipes/conda-recipe-${1#v}/"
+    ssh $PKG@$SERVER "source /etc/profile; CONDA_PY=$CONDA_PY CONDA_NPY=110 conda-build ~/public_html/conda-recipes/conda-recipe-$VERSION/"
 done

--- a/setup.py
+++ b/setup.py
@@ -20,14 +20,14 @@ def missing_or_any_other_newer(path, other_paths):
     provided reference paths.
 
     Parameters
-    ==========
+    ----------
     path: string
-        path to path which might be missing or too old
+        Path to path which might be missing or too old.
     other_paths: iterable of strings
-        reference paths
+        Reference paths.
 
     Returns
-    =======
+    -------
     True if path is older or missing.
     """
     if not os.path.exists(path):


### PR DESCRIPTION
- Specify NumPy version of prebuilt conda packages (let's build for 1.10 for now)
- Build for Python 2.7, 3.4 & 3.5
- Automate publishing of version specific conda recipes.
